### PR TITLE
Fix pre-commit-lite-ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,3 +83,4 @@ repos:
 
 ci:
   autoupdate_schedule: monthly
+  skip: [roxygenize]


### PR DESCRIPTION
try fix with info from
https://lorenzwalthert.github.io/precommit/articles/ci.html

last PR run of `code-check.yml` action failed, although local 

```sh
pre-commit run --all-files
```
passed.

https://github.com/spectral-cockpit/opusreader2/actions/runs/3664885485/jobs/6195588167